### PR TITLE
Add numpy library which is required for OpenCV support

### DIFF
--- a/docker/thumbor-7.4/Dockerfile-alpine
+++ b/docker/thumbor-7.4/Dockerfile-alpine
@@ -40,6 +40,7 @@ RUN set -eux \
         Jinja2==3.0.* envtpl==0.6.* \
         # pycurl is required for thumbor
         pycurl==7.* thumbor==7.4.* thumbor-aws==0.6.* tc_prometheus==2.* \
+        "numpy==1.*,<1.24.0" \
     && thumbor --version && envtpl --help \
     #
     ## Optional extensions

--- a/docker/thumbor-7.4/Dockerfile-slim-alpine
+++ b/docker/thumbor-7.4/Dockerfile-slim-alpine
@@ -40,6 +40,7 @@ RUN set -eux \
         Jinja2==3.0.* envtpl==0.6.* \
         # pycurl is required for thumbor
         pycurl==7.* thumbor==7.4.* thumbor-aws==0.6.* tc_prometheus==2.* \
+        "numpy==1.*,<1.24.0" \
     && thumbor --version && envtpl --help \
     ##
     ## Optional extensions


### PR DESCRIPTION
I have added Numpy which is required for various filters and dectors in thumbor. In particular for us we are using the following detectors setup 
```
        DETECTORS:
              "['thumbor.detectors.face_detector', 'thumbor.detectors.feature_detector']",
```

Version range came from this PR https://github.com/thumbor/thumbor/pull/1537
