### PR TITLE
Change the default endpoint URLs from '' to default(None)

### DIFF
--- a/docker/config/thumbor/thumbor.conf.tpl
+++ b/docker/config/thumbor/thumbor.conf.tpl
@@ -691,15 +691,15 @@ AWS_LOADER_REGION_NAME = '{{ AWS_LOADER_REGION_NAME | default('eu-west-1') }}'
 AWS_LOADER_BUCKET_NAME = '{{ AWS_LOADER_BUCKET_NAME | default('eu-thumbor-1') }}'
 
 ## Secret access key for S3 Loader.
-## Defaults to: ''
+## Defaults to: None
 AWS_LOADER_S3_SECRET_ACCESS_KEY = '{{ AWS_LOADER_S3_SECRET_ACCESS_KEY | default(None) }}'
 
 ## Access key ID for S3 Loader.
-## Defaults to: ''
+## Defaults to: None
 AWS_LOADER_S3_ACCESS_KEY_ID = '{{ AWS_LOADER_S3_ACCESS_KEY_ID | default(None) }}'
 
 ## Endpoint URL for S3 API. Very useful for testing.
-## Defaults to: ''
+## Defaults to: None
 AWS_LOADER_S3_ENDPOINT_URL = '{{ AWS_LOADER_S3_ENDPOINT_URL | default(None) }}'
 
 ## Loader prefix path.
@@ -718,15 +718,15 @@ AWS_STORAGE_REGION_NAME = '{{ AWS_STORAGE_REGION_NAME | default('eu-west-1') }}'
 AWS_STORAGE_BUCKET_NAME = '{{ AWS_STORAGE_BUCKET_NAME | default('thumbor') }}'
 
 ## Secret access key for S3 to allow thumbor to store objects there.
-## Defaults to: ''
+## Defaults to: None
 AWS_STORAGE_S3_SECRET_ACCESS_KEY = '{{ AWS_STORAGE_S3_SECRET_ACCESS_KEY | default(None) }}'
 
 ## Access key ID for S3 to allow thumbor to store objects there.
-## Defaults to: ''
+## Defaults to: None
 AWS_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_STORAGE_S3_ACCESS_KEY_ID | default(None) }}'
 
 ## Endpoint URL for S3 API. Very useful for testing.
-## Defaults to: ''
+## Defaults to: None
 AWS_STORAGE_S3_ENDPOINT_URL = '{{ AWS_STORAGE_S3_ENDPOINT_URL | default(None) }}'
 
 ## Storage prefix path.
@@ -757,11 +757,11 @@ AWS_RESULT_STORAGE_BUCKET_NAME = '{{ AWS_RESULT_STORAGE_BUCKET_NAME | default('t
 AWS_RESULT_STORAGE_S3_SECRET_ACCESS_KEY = '{{ AWS_RESULT_STORAGE_S3_SECRET_ACCESS_KEY | default(None) }}'
 
 ## Access key ID for S3 to allow thumbor to store objects there.
-## Defaults to: ''
+## Defaults to: None
 AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID | default(None) }}'
 
 ## Endpoint URL for S3 API. Very useful for testing.
-## Defaults to: ''
+## Defaults to: None
 AWS_RESULT_STORAGE_S3_ENDPOINT_URL = '{{ AWS_RESULT_STORAGE_S3_ENDPOINT_URL | default(None) }}'
 
 ## Result Storage prefix path.

--- a/docker/config/thumbor/thumbor.conf.tpl
+++ b/docker/config/thumbor/thumbor.conf.tpl
@@ -700,7 +700,7 @@ AWS_LOADER_S3_ACCESS_KEY_ID = '{{ AWS_LOADER_S3_ACCESS_KEY_ID | default(None) }}
 
 ## Endpoint URL for S3 API. Very useful for testing.
 ## Defaults to: ''
-AWS_LOADER_S3_ENDPOINT_URL = '{{ AWS_LOADER_S3_ENDPOINT_URL | default('') }}'
+AWS_LOADER_S3_ENDPOINT_URL = '{{ AWS_LOADER_S3_ENDPOINT_URL | default(None) }}'
 
 ## Loader prefix path.
 ## Defaults to: ''
@@ -727,7 +727,7 @@ AWS_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_STORAGE_S3_ACCESS_KEY_ID | default(None) 
 
 ## Endpoint URL for S3 API. Very useful for testing.
 ## Defaults to: ''
-AWS_STORAGE_S3_ENDPOINT_URL = '{{ AWS_STORAGE_S3_ENDPOINT_URL | default('') }}'
+AWS_STORAGE_S3_ENDPOINT_URL = '{{ AWS_STORAGE_S3_ENDPOINT_URL | default(None) }}'
 
 ## Storage prefix path.
 ## Defaults to: ''
@@ -762,7 +762,7 @@ AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID | 
 
 ## Endpoint URL for S3 API. Very useful for testing.
 ## Defaults to: ''
-AWS_RESULT_STORAGE_S3_ENDPOINT_URL = '{{ AWS_RESULT_STORAGE_S3_ENDPOINT_URL | default('') }}'
+AWS_RESULT_STORAGE_S3_ENDPOINT_URL = '{{ AWS_RESULT_STORAGE_S3_ENDPOINT_URL | default(None) }}'
 
 ## Result Storage prefix path.
 ## Defaults to: None


### PR DESCRIPTION
When using this image with S3 the default of empty '' causes the following error

```
2023-02-13 22:05:30 thumbor:WARNING Error while trying to get the image from the result storage: Invalid endpoint: 
```
I believe this is because it is defaulting to '' instead of None

https://github.com/thumbor/thumbor-aws